### PR TITLE
게임오버 시 동작 구현

### DIFF
--- a/src/common/status_type.rs
+++ b/src/common/status_type.rs
@@ -11,6 +11,7 @@ impl Default for ViewStatusType {
     }
 }
 
+#[derive(PartialEq)]
 pub enum GameStatusType {
     Ready,
     OnGame,

--- a/src/system/data.rs
+++ b/src/system/data.rs
@@ -37,7 +37,11 @@ pub fn save_score(score: u32) -> Result<(), Box<dyn std::error::Error>> {
     scores.sort_by(|a, b| b.score.cmp(&a.score));
     scores.truncate(10); // Keep only top 10 scores
 
-    let json = serde_json::to_string_pretty(&scores)?;
+    let scorelist = ScoreList {
+        scores
+    };
+
+    let json = serde_json::to_string_pretty(&scorelist)?;
     fs::write(SCORE_FILE, json)?;
 
     Ok(())

--- a/src/system/game.rs
+++ b/src/system/game.rs
@@ -6,6 +6,8 @@ use crate::common::direction::Direction;
 use crate::system::data::load_scores;
 use crate::system::resource::GameContext;
 
+use super::data::save_score;
+
 pub fn move_tile(
     mut board: ResMut<Board>,
     mut move_tiles: EventReader<MoveTiles>,
@@ -43,6 +45,15 @@ pub fn update_game(
         board.spawn_tiles();
 
         if !board.is_moveable() {
+            let result = save_score(board.score as u32);
+            match result {
+               Ok(_) => {
+                    print!("score updated to score board\n")
+               }
+                Err(_) => {
+                    print!("Save score failed\n")
+                }
+            }
             print!("Game Over!\n");
         }
     }

--- a/src/system/game.rs
+++ b/src/system/game.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 
+use crate::common::status_type::GameStatusType;
 use crate::component::board::Board;
 use crate::system::events::{MoveTiles, UpdateGameStatus};
 use crate::common::direction::Direction;
@@ -40,11 +41,13 @@ pub fn move_tile(
 pub fn update_game(
     mut board: ResMut<Board>,
     mut update_game_status: EventReader<UpdateGameStatus>,
+    mut game_context: ResMut<GameContext>,
 ) {
     for _ in update_game_status.read() {
         board.spawn_tiles();
 
         if !board.is_moveable() {
+            game_context.lifecycle = GameStatusType::GameOver;
             let result = save_score(board.score as u32);
             match result {
                Ok(_) => {

--- a/src/system/handle_keyboard_input.rs
+++ b/src/system/handle_keyboard_input.rs
@@ -1,34 +1,40 @@
 use bevy::prelude::*;
 
-use crate::common::status_type::ViewStatusType;
+use crate::common::status_type::{GameStatusType, ViewStatusType};
 use crate::common::direction;
 use super::events::{ChangeGameStatus, MoveTiles};
+use super::resource::GameContext;
 
 pub fn handle_keyboard_input(
     keyboard_input: Res<ButtonInput<KeyCode>>,
+    game_context: ResMut<GameContext>,
     mut system_event: EventWriter<ChangeGameStatus>,
     mut game_event: EventWriter<MoveTiles>,
 ) {
-    if keyboard_input.just_pressed(KeyCode::ArrowUp) {
-        game_event.send(MoveTiles {
-            direction: direction::Direction::Up,
-        });
-
-    } else if keyboard_input.just_pressed(KeyCode::ArrowDown) {
-        game_event.send(MoveTiles {
-            direction: direction::Direction::Down,
-        });
-
-    } else if keyboard_input.just_pressed(KeyCode::ArrowLeft) {
-        game_event.send(MoveTiles {
-            direction: direction::Direction::Left,
-        });
-
-    } else if keyboard_input.just_pressed(KeyCode::ArrowRight) {
-        game_event.send(MoveTiles {
-            direction: direction::Direction::Right,
-        });
-    } else if keyboard_input.just_pressed(KeyCode::Escape) {
+    if game_context.lifecycle == GameStatusType::OnGame {
+        if keyboard_input.just_pressed(KeyCode::ArrowUp) {
+            game_event.send(MoveTiles {
+                direction: direction::Direction::Up,
+            });
+    
+        } else if keyboard_input.just_pressed(KeyCode::ArrowDown) {
+            game_event.send(MoveTiles {
+                direction: direction::Direction::Down,
+            });
+    
+        } else if keyboard_input.just_pressed(KeyCode::ArrowLeft) {
+            game_event.send(MoveTiles {
+                direction: direction::Direction::Left,
+            });
+    
+        } else if keyboard_input.just_pressed(KeyCode::ArrowRight) {
+            game_event.send(MoveTiles {
+                direction: direction::Direction::Right,
+            });
+        }
+    }
+    
+    if keyboard_input.just_pressed(KeyCode::Escape) {
         system_event.send(ChangeGameStatus(ViewStatusType::MainMenu));
     } else if keyboard_input.just_pressed(KeyCode::KeyR) {
         system_event.send(ChangeGameStatus(ViewStatusType::Rank));


### PR DESCRIPTION
- 최종 점수를 스코어보드에 갱신
- 게임 종료 상태를 맞추어 게임 조작 동작이 일어나지 않도록 수정